### PR TITLE
PHP Path Fix

### DIFF
--- a/Run.bat
+++ b/Run.bat
@@ -1,3 +1,4 @@
 @echo off
-php Run.php
+
+C:\xampp\php\php.exe -f "C:\xampp\htdocs\run.php"
 pause


### PR DESCRIPTION
Sometimes PHP doesn't get added to PATH on some machines. This fixes it so that adding it to the PATH is not needed.